### PR TITLE
Fix portfolio tab mapping and add price charts

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <title>株価通知アプリ</title>
     <link rel="stylesheet" href="styles.css">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
     <div class="container">
@@ -58,6 +59,6 @@
         </div>
     </div>
 
-    <script src="script.js?v=2"></script>
+    <script src="script.js?v=3"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -163,6 +163,12 @@ header h1 {
     color: #7f8c8d;
 }
 
+.chart-container {
+    position: relative;
+    height: 120px;
+    margin: 15px 0;
+}
+
 .stock-details {
     margin-top: 15px;
     padding-top: 15px;


### PR DESCRIPTION
## Summary
- map tab ids to their data/config grids so portfolio and other tabs populate correctly
- fetch or synthesize historical price data and render per-stock sparklines with Chart.js
- preload initial tab content and bust cache for the updated script

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9af2a5e5083229e0ddc3e3b49fb16