### PR TITLE
Update simple stock page with multi-period price comparisons

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>株価通知アプリ</title>
-    <link rel="stylesheet" href="styles.css?v=10">
+    <link rel="stylesheet" href="styles.css?v=11">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
 </head>
 <body>
@@ -58,6 +58,6 @@
         </div>
     </div>
 
-    <script src="script.js?v=10"></script>
+    <script src="script.js?v=11"></script>
 </body>
 </html>

--- a/simple-stock.html
+++ b/simple-stock.html
@@ -4,397 +4,623 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>シンプル株価アプリ</title>
-        <style>
-            body { font-family: Arial, sans-serif; background: #f0f0f0; margin: 0; padding: 20px; }
-            .container { max-width: 800px; margin: 0 auto; }
-            h1 { text-align: center; color: #333; margin-bottom: 30px; }
-            .tabs { display: flex; margin-bottom: 20px; }
-            .tab { padding: 10px 20px; background: #ddd; border: none; cursor: pointer; margin-right: 5px; }
-            .tab.active { background: #007bff; color: white; }
-            .content { background: white; padding: 20px; border-radius: 5px; }
-            
-            .stock { 
-                background: #f8f9fa; 
-                border: 1px solid #e9ecef; 
-                border-radius: 8px; 
-                padding: 15px; 
-                margin-bottom: 15px; 
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background: #f0f0f0;
+            margin: 0;
+            padding: 20px;
+            color: #333;
+        }
+        .container {
+            max-width: 900px;
+            margin: 0 auto;
+        }
+        h1 {
+            text-align: center;
+            color: #333;
+            margin-bottom: 30px;
+        }
+        .tabs {
+            display: flex;
+            flex-wrap: wrap;
+            margin-bottom: 20px;
+            gap: 8px;
+        }
+        .tab {
+            padding: 10px 20px;
+            background: #ddd;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            transition: background 0.2s ease;
+        }
+        .tab.active {
+            background: #007bff;
+            color: white;
+        }
+        .tab:focus {
+            outline: 2px solid #0056b3;
+        }
+        .content {
+            background: white;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+        }
+        .tab-panel {
+            display: none;
+        }
+        .tab-panel.active {
+            display: block;
+        }
+        .stock-group-title {
+            color: #007bff;
+            margin: 24px 0 12px;
+            font-size: 18px;
+            border-bottom: 2px solid #007bff;
+            padding-bottom: 6px;
+        }
+        .stock {
+            background: #f8f9fa;
+            border: 1px solid #e9ecef;
+            border-radius: 10px;
+            padding: 16px;
+            margin-bottom: 16px;
+        }
+        .stock-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .stock-name {
+            font-size: 20px;
+            font-weight: bold;
+            color: #333;
+        }
+        .stock-price {
+            font-size: 24px;
+            font-weight: bold;
+            color: #333;
+        }
+        .stock-details {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+            gap: 10px 16px;
+            margin-top: 16px;
+        }
+        .detail-item {
+            background: white;
+            border: 1px solid #e0e0e0;
+            border-radius: 6px;
+            padding: 10px 12px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 12px;
+        }
+        .detail-label {
+            font-size: 14px;
+            color: #666;
+        }
+        .detail-value {
+            font-size: 15px;
+            font-weight: bold;
+        }
+        .detail-value.positive {
+            color: #28a745;
+        }
+        .detail-value.negative {
+            color: #dc3545;
+        }
+        @media (max-width: 600px) {
+            .stock-details {
+                grid-template-columns: 1fr;
             }
-            .stock-name { 
-                font-size: 18px; 
-                font-weight: bold; 
-                color: #333; 
-                margin-bottom: 8px; 
+            .stock-header {
+                flex-direction: column;
+                align-items: flex-start;
             }
-            .stock-price { 
-                font-size: 24px; 
-                font-weight: bold; 
-                color: #333; 
-                margin-bottom: 5px; 
+            .stock-price {
+                font-size: 22px;
             }
-            .stock-change { 
-                font-size: 16px; 
-                font-weight: bold; 
-                margin-bottom: 10px; 
-            }
-            .stock-change.positive { color: #28a745; }
-            .stock-change.negative { color: #dc3545; }
-            .stock-details { 
-                display: grid; 
-                grid-template-columns: 1fr 1fr; 
-                gap: 8px; 
-                margin-top: 10px; 
-            }
-            .detail-item { 
-                display: flex; 
-                justify-content: space-between; 
-                padding: 5px 0; 
-                border-bottom: 1px solid #e9ecef; 
-            }
-            .detail-label { 
-                color: #666; 
-                font-size: 14px; 
-            }
-            .detail-value { 
-                font-weight: bold; 
-                color: #333; 
-                font-size: 14px; 
-            }
-            h3 { 
-                color: #007bff; 
-                margin: 20px 0 15px 0; 
-                font-size: 18px; 
-                border-bottom: 2px solid #007bff; 
-                padding-bottom: 5px; 
-            }
-        </style>
+        }
+    </style>
 </head>
 <body>
     <div class="container">
         <h1>シンプル株価アプリ</h1>
-        
+
         <div class="tabs">
-            <button class="tab active" onclick="showTab('my-stocks')">保有銘柄</button>
-            <button class="tab" onclick="showTab('watchlist')">ウォッチリスト</button>
-            <button class="tab" onclick="showTab('hot-stocks')">ホット銘柄</button>
+            <button class="tab active" data-tab="my-stocks">保有銘柄</button>
+            <button class="tab" data-tab="watchlist">ウォッチリスト</button>
+            <button class="tab" data-tab="hot-stocks">ホット銘柄</button>
         </div>
-        
+
         <div class="content">
-            <div id="my-stocks">
+            <section id="my-stocks" class="tab-panel active">
                 <h2>保有銘柄</h2>
-                
-                <h3>投資信託</h3>
+
+                <h3 class="stock-group-title">投資信託</h3>
                 <div class="stock">
-                    <div class="stock-name">iFreeNEXT FANG+インデックス</div>
-                    <div class="stock-price">¥15,420</div>
-                    <div class="stock-change positive">+¥180 (+1.18%)</div>
+                    <div class="stock-header">
+                        <div class="stock-name">iFreeNEXT FANG+インデックス</div>
+                        <div class="stock-price">¥15,420</div>
+                    </div>
                     <div class="stock-details">
                         <div class="detail-item">
-                            <span class="detail-label">前日終値</span>
-                            <span class="detail-value">¥15,240</span>
+                            <span class="detail-label">前日比価格</span>
+                            <span class="detail-value positive">+¥180 (+1.18%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">高値</span>
-                            <span class="detail-value">¥15,580</span>
+                            <span class="detail-label">一週間前比価格</span>
+                            <span class="detail-value positive">+¥420 (+2.80%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">安値</span>
-                            <span class="detail-value">¥15,190</span>
+                            <span class="detail-label">1ヶ月前比価格</span>
+                            <span class="detail-value positive">+¥620 (+4.19%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">出来高</span>
-                            <span class="detail-value">2.1M</span>
+                            <span class="detail-label">3ヶ月前比価格</span>
+                            <span class="detail-value positive">+¥1,230 (+8.67%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">半年前比価格</span>
+                            <span class="detail-value positive">+¥2,140 (+16.12%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">一年前比価格</span>
+                            <span class="detail-value positive">+¥3,120 (+25.38%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">二年前比価格</span>
+                            <span class="detail-value positive">+¥4,580 (+42.27%)</span>
                         </div>
                     </div>
                 </div>
-                
+
                 <div class="stock">
-                    <div class="stock-name">eMAXIS Slim 米国株式(S&P500)</div>
-                    <div class="stock-price">¥12,850</div>
-                    <div class="stock-change positive">+¥95 (+0.74%)</div>
+                    <div class="stock-header">
+                        <div class="stock-name">eMAXIS Slim 米国株式(S&P500)</div>
+                        <div class="stock-price">¥12,850</div>
+                    </div>
                     <div class="stock-details">
                         <div class="detail-item">
-                            <span class="detail-label">前日終値</span>
-                            <span class="detail-value">¥12,755</span>
+                            <span class="detail-label">前日比価格</span>
+                            <span class="detail-value positive">+¥95 (+0.74%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">高値</span>
-                            <span class="detail-value">¥12,920</span>
+                            <span class="detail-label">一週間前比価格</span>
+                            <span class="detail-value positive">+¥180 (+1.42%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">安値</span>
-                            <span class="detail-value">¥12,680</span>
+                            <span class="detail-label">1ヶ月前比価格</span>
+                            <span class="detail-value positive">+¥310 (+2.47%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">出来高</span>
-                            <span class="detail-value">1.8M</span>
+                            <span class="detail-label">3ヶ月前比価格</span>
+                            <span class="detail-value positive">+¥520 (+4.22%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">半年前比価格</span>
+                            <span class="detail-value positive">+¥780 (+6.46%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">一年前比価格</span>
+                            <span class="detail-value positive">+¥1,120 (+9.55%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">二年前比価格</span>
+                            <span class="detail-value positive">+¥1,980 (+18.23%)</span>
                         </div>
                     </div>
                 </div>
-                
-                <h3>個別株</h3>
+
+                <h3 class="stock-group-title">個別株</h3>
                 <div class="stock">
-                    <div class="stock-name">GXUS テック・トップ２０</div>
-                    <div class="stock-price">¥8,750</div>
-                    <div class="stock-change positive">+¥120 (+1.39%)</div>
+                    <div class="stock-header">
+                        <div class="stock-name">GXUS テック・トップ２０</div>
+                        <div class="stock-price">¥8,750</div>
+                    </div>
                     <div class="stock-details">
                         <div class="detail-item">
-                            <span class="detail-label">前日終値</span>
-                            <span class="detail-value">¥8,630</span>
+                            <span class="detail-label">前日比価格</span>
+                            <span class="detail-value positive">+¥120 (+1.39%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">高値</span>
-                            <span class="detail-value">¥8,890</span>
+                            <span class="detail-label">一週間前比価格</span>
+                            <span class="detail-value positive">+¥260 (+3.06%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">安値</span>
-                            <span class="detail-value">¥8,580</span>
+                            <span class="detail-label">1ヶ月前比価格</span>
+                            <span class="detail-value positive">+¥480 (+5.81%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">出来高</span>
-                            <span class="detail-value">850K</span>
+                            <span class="detail-label">3ヶ月前比価格</span>
+                            <span class="detail-value positive">+¥940 (+12.04%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">半年前比価格</span>
+                            <span class="detail-value positive">+¥1,420 (+19.37%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">一年前比価格</span>
+                            <span class="detail-value positive">+¥1,980 (+29.24%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">二年前比価格</span>
+                            <span class="detail-value positive">+¥2,650 (+43.49%)</span>
                         </div>
                     </div>
                 </div>
-                
+
                 <div class="stock">
-                    <div class="stock-name">SOXL - Direxion デイリー 半導体株</div>
-                    <div class="stock-price">$45.20</div>
-                    <div class="stock-change positive">+$2.10 (+4.87%)</div>
+                    <div class="stock-header">
+                        <div class="stock-name">SOXL - Direxion デイリー 半導体株</div>
+                        <div class="stock-price">$45.20</div>
+                    </div>
                     <div class="stock-details">
                         <div class="detail-item">
-                            <span class="detail-label">前日終値</span>
-                            <span class="detail-value">$43.10</span>
+                            <span class="detail-label">前日比価格</span>
+                            <span class="detail-value positive">+$2.10 (+4.87%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">高値</span>
-                            <span class="detail-value">$46.80</span>
+                            <span class="detail-label">一週間前比価格</span>
+                            <span class="detail-value positive">+$3.40 (+8.13%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">安値</span>
-                            <span class="detail-value">$44.50</span>
+                            <span class="detail-label">1ヶ月前比価格</span>
+                            <span class="detail-value positive">+$5.80 (+14.71%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">出来高</span>
-                            <span class="detail-value">12.5M</span>
+                            <span class="detail-label">3ヶ月前比価格</span>
+                            <span class="detail-value positive">+$9.10 (+25.20%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">半年前比価格</span>
+                            <span class="detail-value positive">+$12.60 (+38.62%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">一年前比価格</span>
+                            <span class="detail-value positive">+$16.40 (+57.00%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">二年前比価格</span>
+                            <span class="detail-value positive">+$20.90 (+85.77%)</span>
                         </div>
                     </div>
                 </div>
-                
+
                 <div class="stock">
-                    <div class="stock-name">TECL - Direxion デイリー テクノロジー</div>
-                    <div class="stock-price">$78.50</div>
-                    <div class="stock-change positive">+$1.80 (+2.35%)</div>
+                    <div class="stock-header">
+                        <div class="stock-name">TECL - Direxion デイリー テクノロジー</div>
+                        <div class="stock-price">$78.50</div>
+                    </div>
                     <div class="stock-details">
                         <div class="detail-item">
-                            <span class="detail-label">前日終値</span>
-                            <span class="detail-value">$76.70</span>
+                            <span class="detail-label">前日比価格</span>
+                            <span class="detail-value positive">+$1.80 (+2.35%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">高値</span>
-                            <span class="detail-value">$79.20</span>
+                            <span class="detail-label">一週間前比価格</span>
+                            <span class="detail-value positive">+$2.90 (+3.83%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">安値</span>
-                            <span class="detail-value">$77.10</span>
+                            <span class="detail-label">1ヶ月前比価格</span>
+                            <span class="detail-value positive">+$4.70 (+6.37%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">出来高</span>
-                            <span class="detail-value">8.3M</span>
+                            <span class="detail-label">3ヶ月前比価格</span>
+                            <span class="detail-value positive">+$7.60 (+10.73%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">半年前比価格</span>
+                            <span class="detail-value positive">+$11.20 (+16.64%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">一年前比価格</span>
+                            <span class="detail-value positive">+$15.40 (+24.40%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">二年前比価格</span>
+                            <span class="detail-value positive">+$22.10 (+39.16%)</span>
                         </div>
                     </div>
                 </div>
-                
+
                 <div class="stock">
-                    <div class="stock-name">SPXL - Direxion デイリー S&P 500</div>
-                    <div class="stock-price">$125.80</div>
-                    <div class="stock-change positive">+$2.40 (+1.94%)</div>
+                    <div class="stock-header">
+                        <div class="stock-name">SPXL - Direxion デイリー S&P 500</div>
+                        <div class="stock-price">$125.80</div>
+                    </div>
                     <div class="stock-details">
                         <div class="detail-item">
-                            <span class="detail-label">前日終値</span>
-                            <span class="detail-value">$123.40</span>
+                            <span class="detail-label">前日比価格</span>
+                            <span class="detail-value positive">+$2.40 (+1.94%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">高値</span>
-                            <span class="detail-value">$127.50</span>
+                            <span class="detail-label">一週間前比価格</span>
+                            <span class="detail-value positive">+$4.20 (+3.46%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">安値</span>
-                            <span class="detail-value">$124.20</span>
+                            <span class="detail-label">1ヶ月前比価格</span>
+                            <span class="detail-value positive">+$6.80 (+5.72%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">出来高</span>
-                            <span class="detail-value">5.7M</span>
+                            <span class="detail-label">3ヶ月前比価格</span>
+                            <span class="detail-value positive">+$11.90 (+10.45%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">半年前比価格</span>
+                            <span class="detail-value positive">+$18.40 (+17.13%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">一年前比価格</span>
+                            <span class="detail-value positive">+$24.60 (+24.33%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">二年前比価格</span>
+                            <span class="detail-value positive">+$35.20 (+38.88%)</span>
                         </div>
                     </div>
                 </div>
-                
+
                 <div class="stock">
-                    <div class="stock-name">FAS - Direxion デイリー 米国金融株</div>
-                    <div class="stock-price">$95.60</div>
-                    <div class="stock-change negative">-$1.20 (-1.24%)</div>
+                    <div class="stock-header">
+                        <div class="stock-name">FAS - Direxion デイリー 米国金融株</div>
+                        <div class="stock-price">$95.60</div>
+                    </div>
                     <div class="stock-details">
                         <div class="detail-item">
-                            <span class="detail-label">前日終値</span>
-                            <span class="detail-value">$96.80</span>
+                            <span class="detail-label">前日比価格</span>
+                            <span class="detail-value negative">-$1.20 (-1.24%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">高値</span>
-                            <span class="detail-value">$98.40</span>
+                            <span class="detail-label">一週間前比価格</span>
+                            <span class="detail-value positive">+$0.90 (+0.95%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">安値</span>
-                            <span class="detail-value">$94.90</span>
+                            <span class="detail-label">1ヶ月前比価格</span>
+                            <span class="detail-value positive">+$2.40 (+2.57%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">出来高</span>
-                            <span class="detail-value">3.2M</span>
+                            <span class="detail-label">3ヶ月前比価格</span>
+                            <span class="detail-value positive">+$4.10 (+4.48%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">半年前比価格</span>
+                            <span class="detail-value positive">+$6.80 (+7.66%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">一年前比価格</span>
+                            <span class="detail-value positive">+$9.50 (+11.03%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">二年前比価格</span>
+                            <span class="detail-value positive">+$14.80 (+18.31%)</span>
                         </div>
                     </div>
                 </div>
-            </div>
-            
-            <div id="watchlist" style="display: none;">
+            </section>
+
+            <section id="watchlist" class="tab-panel">
                 <h2>ウォッチリスト</h2>
-                <p>銘柄がありません</p>
-            </div>
-            
-            <div id="hot-stocks" style="display: none;">
+                <p>ウォッチリストに銘柄はありません。</p>
+            </section>
+
+            <section id="hot-stocks" class="tab-panel">
                 <h2>FANG+銘柄</h2>
+
                 <div class="stock">
-                    <div class="stock-name">AAPL - Apple Inc</div>
-                    <div class="stock-price">$180.00</div>
-                    <div class="stock-change positive">+$2.50 (+1.41%)</div>
+                    <div class="stock-header">
+                        <div class="stock-name">AAPL - Apple Inc</div>
+                        <div class="stock-price">$180.00</div>
+                    </div>
                     <div class="stock-details">
                         <div class="detail-item">
-                            <span class="detail-label">前日終値</span>
-                            <span class="detail-value">$177.50</span>
+                            <span class="detail-label">前日比価格</span>
+                            <span class="detail-value positive">+$2.50 (+1.41%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">高値</span>
-                            <span class="detail-value">$182.30</span>
+                            <span class="detail-label">一週間前比価格</span>
+                            <span class="detail-value positive">+$4.70 (+2.68%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">安値</span>
-                            <span class="detail-value">$178.90</span>
+                            <span class="detail-label">1ヶ月前比価格</span>
+                            <span class="detail-value positive">+$7.80 (+4.53%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">出来高</span>
-                            <span class="detail-value">45.2M</span>
+                            <span class="detail-label">3ヶ月前比価格</span>
+                            <span class="detail-value positive">+$12.40 (+7.40%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">半年前比価格</span>
+                            <span class="detail-value positive">+$18.90 (+11.72%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">一年前比価格</span>
+                            <span class="detail-value positive">+$26.50 (+17.26%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">二年前比価格</span>
+                            <span class="detail-value positive">+$38.20 (+26.96%)</span>
                         </div>
                     </div>
                 </div>
-                
+
                 <div class="stock">
-                    <div class="stock-name">GOOGL - Alphabet Inc Class A</div>
-                    <div class="stock-price">$140.00</div>
-                    <div class="stock-change positive">+$1.80 (+1.30%)</div>
+                    <div class="stock-header">
+                        <div class="stock-name">GOOGL - Alphabet Inc Class A</div>
+                        <div class="stock-price">$140.00</div>
+                    </div>
                     <div class="stock-details">
                         <div class="detail-item">
-                            <span class="detail-label">前日終値</span>
-                            <span class="detail-value">$138.20</span>
+                            <span class="detail-label">前日比価格</span>
+                            <span class="detail-value positive">+$1.80 (+1.30%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">高値</span>
-                            <span class="detail-value">$142.50</span>
+                            <span class="detail-label">一週間前比価格</span>
+                            <span class="detail-value positive">+$3.20 (+2.34%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">安値</span>
-                            <span class="detail-value">$139.10</span>
+                            <span class="detail-label">1ヶ月前比価格</span>
+                            <span class="detail-value positive">+$5.90 (+4.40%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">出来高</span>
-                            <span class="detail-value">28.7M</span>
+                            <span class="detail-label">3ヶ月前比価格</span>
+                            <span class="detail-value positive">+$8.70 (+6.63%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">半年前比価格</span>
+                            <span class="detail-value positive">+$13.40 (+10.58%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">一年前比価格</span>
+                            <span class="detail-value positive">+$19.80 (+16.49%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">二年前比価格</span>
+                            <span class="detail-value positive">+$28.60 (+25.68%)</span>
                         </div>
                     </div>
                 </div>
-                
+
                 <div class="stock">
-                    <div class="stock-name">AMZN - Amazon.com Inc</div>
-                    <div class="stock-price">$150.00</div>
-                    <div class="stock-change negative">-$2.00 (-1.32%)</div>
+                    <div class="stock-header">
+                        <div class="stock-name">AMZN - Amazon.com Inc</div>
+                        <div class="stock-price">$150.00</div>
+                    </div>
                     <div class="stock-details">
                         <div class="detail-item">
-                            <span class="detail-label">前日終値</span>
-                            <span class="detail-value">$152.00</span>
+                            <span class="detail-label">前日比価格</span>
+                            <span class="detail-value negative">-$2.00 (-1.32%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">高値</span>
-                            <span class="detail-value">$153.80</span>
+                            <span class="detail-label">一週間前比価格</span>
+                            <span class="detail-value negative">-$1.40 (-0.93%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">安値</span>
-                            <span class="detail-value">$148.50</span>
+                            <span class="detail-label">1ヶ月前比価格</span>
+                            <span class="detail-value positive">+$2.60 (+1.77%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">出来高</span>
-                            <span class="detail-value">32.1M</span>
+                            <span class="detail-label">3ヶ月前比価格</span>
+                            <span class="detail-value positive">+$5.80 (+4.02%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">半年前比価格</span>
+                            <span class="detail-value positive">+$9.20 (+6.53%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">一年前比価格</span>
+                            <span class="detail-value positive">+$14.50 (+10.69%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">二年前比価格</span>
+                            <span class="detail-value positive">+$21.30 (+16.56%)</span>
                         </div>
                     </div>
                 </div>
-                
+
                 <div class="stock">
-                    <div class="stock-name">NFLX - Netflix Inc</div>
-                    <div class="stock-price">$400.00</div>
-                    <div class="stock-change positive">+$5.00 (+1.27%)</div>
+                    <div class="stock-header">
+                        <div class="stock-name">NFLX - Netflix Inc</div>
+                        <div class="stock-price">$400.00</div>
+                    </div>
                     <div class="stock-details">
                         <div class="detail-item">
-                            <span class="detail-label">前日終値</span>
-                            <span class="detail-value">$395.00</span>
+                            <span class="detail-label">前日比価格</span>
+                            <span class="detail-value positive">+$5.00 (+1.27%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">高値</span>
-                            <span class="detail-value">$405.20</span>
+                            <span class="detail-label">一週間前比価格</span>
+                            <span class="detail-value positive">+$7.90 (+2.02%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">安値</span>
-                            <span class="detail-value">$398.50</span>
+                            <span class="detail-label">1ヶ月前比価格</span>
+                            <span class="detail-value positive">+$12.30 (+3.17%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">出来高</span>
-                            <span class="detail-value">15.8M</span>
+                            <span class="detail-label">3ヶ月前比価格</span>
+                            <span class="detail-value positive">+$21.40 (+5.65%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">半年前比価格</span>
+                            <span class="detail-value positive">+$34.80 (+9.52%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">一年前比価格</span>
+                            <span class="detail-value positive">+$46.90 (+13.28%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">二年前比価格</span>
+                            <span class="detail-value positive">+$62.70 (+18.62%)</span>
                         </div>
                     </div>
                 </div>
-                
+
                 <div class="stock">
-                    <div class="stock-name">TSLA - Tesla Inc</div>
-                    <div class="stock-price">$250.00</div>
-                    <div class="stock-change positive">+$8.00 (+3.31%)</div>
+                    <div class="stock-header">
+                        <div class="stock-name">TSLA - Tesla Inc</div>
+                        <div class="stock-price">$250.00</div>
+                    </div>
                     <div class="stock-details">
                         <div class="detail-item">
-                            <span class="detail-label">前日終値</span>
-                            <span class="detail-value">$242.00</span>
+                            <span class="detail-label">前日比価格</span>
+                            <span class="detail-value positive">+$8.00 (+3.31%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">高値</span>
-                            <span class="detail-value">$255.30</span>
+                            <span class="detail-label">一週間前比価格</span>
+                            <span class="detail-value positive">+$12.20 (+5.13%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">安値</span>
-                            <span class="detail-value">$248.90</span>
+                            <span class="detail-label">1ヶ月前比価格</span>
+                            <span class="detail-value positive">+$18.40 (+7.95%)</span>
                         </div>
                         <div class="detail-item">
-                            <span class="detail-label">出来高</span>
-                            <span class="detail-value">67.3M</span>
+                            <span class="detail-label">3ヶ月前比価格</span>
+                            <span class="detail-value positive">+$27.60 (+12.40%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">半年前比価格</span>
+                            <span class="detail-value positive">+$39.80 (+18.94%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">一年前比価格</span>
+                            <span class="detail-value positive">+$52.40 (+26.59%)</span>
+                        </div>
+                        <div class="detail-item">
+                            <span class="detail-label">二年前比価格</span>
+                            <span class="detail-value positive">+$71.60 (+40.94%)</span>
                         </div>
                     </div>
                 </div>
-            </div>
+            </section>
         </div>
     </div>
-    
+
     <script>
-        function showTab(tabName) {
-            document.getElementById('my-stocks').style.display = 'none';
-            document.getElementById('watchlist').style.display = 'none';
-            document.getElementById('hot-stocks').style.display = 'none';
-            
-            document.querySelectorAll('.tab').forEach(tab => tab.classList.remove('active'));
-            event.target.classList.add('active');
-            
-            document.getElementById(tabName).style.display = 'block';
-        }
+        document.addEventListener('DOMContentLoaded', () => {
+            const tabs = document.querySelectorAll('.tab');
+            const panels = document.querySelectorAll('.tab-panel');
+
+            tabs.forEach(tab => {
+                tab.addEventListener('click', () => {
+                    const targetId = tab.getAttribute('data-tab');
+
+                    tabs.forEach(btn => btn.classList.remove('active'));
+                    panels.forEach(panel => panel.classList.remove('active'));
+
+                    tab.classList.add('active');
+                    const targetPanel = document.getElementById(targetId);
+                    if (targetPanel) {
+                        targetPanel.classList.add('active');
+                    }
+                });
+            });
+        });
     </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -144,53 +144,48 @@ header h1 {
     font-size: 1.2rem;
     font-weight: 700;
     color: #2d3748;
-    margin-bottom: 4px;
+    margin-bottom: 8px;
 }
 
-.stock-change {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    font-size: 0.75rem;
-    font-weight: 600;
-    padding: 2px 6px;
-    border-radius: 4px;
-}
-
-.stock-change.positive {
-    color: #38a169;
-    background: rgba(56, 161, 105, 0.1);
-}
-
-.stock-change.negative {
-    color: #e53e3e;
-    background: rgba(229, 62, 62, 0.1);
-}
-
-
-/* 詳細情報 */
-.stock-details {
-    margin-top: 8px;
-    padding-top: 8px;
-    border-top: 1px solid #e2e8f0;
-    display: grid;
-    grid-template-columns: 1fr 1fr;
+.comparison-list {
+    display: flex;
+    flex-direction: column;
     gap: 6px;
 }
 
-.detail-item {
+.comparison-item {
     display: flex;
     justify-content: space-between;
-    font-size: 0.7rem;
-}
-
-.detail-label {
-    color: #718096;
-}
-
-.detail-value {
-    font-weight: 600;
+    align-items: center;
+    padding: 6px 8px;
+    border-radius: 6px;
+    font-size: 0.75rem;
+    background: rgba(226, 232, 240, 0.6);
     color: #2d3748;
+    transition: background 0.2s ease;
+}
+
+.comparison-item.positive {
+    color: #1f6f43;
+    background: rgba(56, 161, 105, 0.14);
+}
+
+.comparison-item.negative {
+    color: #c53030;
+    background: rgba(229, 62, 62, 0.14);
+}
+
+.comparison-item.neutral {
+    color: #4a5568;
+    background: rgba(226, 232, 240, 0.8);
+}
+
+.comparison-label {
+    font-weight: 600;
+}
+
+.comparison-value {
+    font-weight: 700;
 }
 
 /* ローディング・エラー */


### PR DESCRIPTION
## Summary
- redesign the simple stock page to list the requested multi-period price comparisons for each holding
- refresh the layout and tab interactions to highlight price details with responsive styling

## Testing
- Manual verification via local browser (simple-stock.html)


------
https://chatgpt.com/codex/tasks/task_e_68dcb2741e60832289d98e06157927c7