### PR TITLE
Append cache-busting version to favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>株価通知アプリ</title>
+    <link rel="icon" type="image/svg+xml" href="stock-icon.svg?v=2">
     <link rel="stylesheet" href="styles.css?v=10">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
 </head>

--- a/stock-icon.svg
+++ b/stock-icon.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#0d47a1" />
+      <stop offset="100%" stop-color="#1976d2" />
+    </linearGradient>
+    <linearGradient id="line" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#ffeb3b" />
+      <stop offset="100%" stop-color="#ff9800" />
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%">
+      <feDropShadow dx="0" dy="2" stdDeviation="2" flood-color="#000" flood-opacity="0.2" />
+    </filter>
+  </defs>
+  <rect width="64" height="64" rx="12" ry="12" fill="url(#bg)" />
+  <g filter="url(#shadow)" stroke-linecap="round" stroke-linejoin="round" fill="none" stroke-width="4">
+    <polyline points="12 44 24 32 32 36 44 20 52 28" stroke="url(#line)" />
+    <circle cx="24" cy="32" r="3" fill="#fff" stroke="url(#line)" stroke-width="2" />
+    <circle cx="44" cy="20" r="3" fill="#fff" stroke="url(#line)" stroke-width="2" />
+    <circle cx="52" cy="28" r="3" fill="#fff" stroke="url(#line)" stroke-width="2" />
+  </g>
+  <path d="M16 48h36" stroke="#bbdefb" stroke-width="3" stroke-linecap="round" />
+</svg>


### PR DESCRIPTION
## Summary
- add the v2 cache-busting query parameter to the favicon link so the correct icon loads

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e22c87489083228ebeefc8c26a60b8